### PR TITLE
Add game data models

### DIFF
--- a/lib/enums/alliance.dart
+++ b/lib/enums/alliance.dart
@@ -1,0 +1,4 @@
+enum Alliance {
+  red,
+  blue,
+}

--- a/lib/enums/charge_station.dart
+++ b/lib/enums/charge_station.dart
@@ -1,0 +1,5 @@
+enum ChargeStationState {
+  docked,
+  engaged,
+  failed,
+}

--- a/lib/enums/driver_station.dart
+++ b/lib/enums/driver_station.dart
@@ -1,0 +1,8 @@
+enum DriverStation {
+  first(1),
+  second(2),
+  third(3);
+
+  const DriverStation(this.value);
+  final int value;
+}

--- a/lib/enums/game_piece.dart
+++ b/lib/enums/game_piece.dart
@@ -1,0 +1,4 @@
+enum GamePiece {
+  cube,
+  cone,
+}

--- a/lib/enums/grid_level.dart
+++ b/lib/enums/grid_level.dart
@@ -1,0 +1,5 @@
+enum GridLevel {
+  low,
+  middle,
+  high,
+}

--- a/lib/enums/grid_zone.dart
+++ b/lib/enums/grid_zone.dart
@@ -1,0 +1,8 @@
+enum GridZone {
+  nearFeeder(1),
+  coOp(2),
+  nearBorder(3);
+
+  const GridZone(this.value);
+  final int value;
+}

--- a/lib/enums/pickup_zone.dart
+++ b/lib/enums/pickup_zone.dart
@@ -1,0 +1,4 @@
+enum PickupZone {
+  feeder,
+  floor,
+}

--- a/lib/models/autonomous.dart
+++ b/lib/models/autonomous.dart
@@ -1,0 +1,15 @@
+// Project imports:
+import 'package:neatteam_scouting_2023/enums/charge_station.dart';
+import 'package:neatteam_scouting_2023/models/cycle.dart';
+
+class Autonomous {
+  Autonomous()
+      : cycles = [],
+        didChargeStation = false,
+        isGamePieceInRobot = true;
+
+  List<Cycle> cycles;
+  bool didChargeStation;
+  ChargeStationState? chargeStationState;
+  bool isGamePieceInRobot;
+}

--- a/lib/models/cycle.dart
+++ b/lib/models/cycle.dart
@@ -1,0 +1,25 @@
+// Project imports:
+import 'package:neatteam_scouting_2023/enums/game_piece.dart';
+import 'package:neatteam_scouting_2023/enums/grid_level.dart';
+import 'package:neatteam_scouting_2023/enums/grid_zone.dart';
+import 'package:neatteam_scouting_2023/enums/pickup_zone.dart';
+import 'package:neatteam_scouting_2023/models/team.dart';
+
+class Cycle {
+  Cycle({
+    required this.cycleNumber,
+    this.isHalf = false,
+  })  : isDefended = false,
+        isSuccessful = true;
+
+  int cycleNumber;
+  bool isDefended;
+  Team? defendingTeam;
+  GamePiece? gamePiece;
+  PickupZone? pickupZone;
+  GridLevel? gridLevel;
+  GridZone? gridZone;
+  double? cycleTime;
+  bool isSuccessful;
+  bool isHalf;
+}

--- a/lib/models/endgame.dart
+++ b/lib/models/endgame.dart
@@ -1,0 +1,10 @@
+// Project imports:
+import 'package:neatteam_scouting_2023/enums/charge_station.dart';
+
+class Endgame {
+  Endgame({this.didChargeStation = true});
+
+  bool didChargeStation;
+  ChargeStationState? chargeStationState;
+  double? dockedTime;
+}

--- a/lib/models/match.dart
+++ b/lib/models/match.dart
@@ -1,0 +1,25 @@
+// Project imports:
+import 'package:neatteam_scouting_2023/enums/alliance.dart';
+import 'package:neatteam_scouting_2023/enums/driver_station.dart';
+import 'package:neatteam_scouting_2023/models/autonomous.dart';
+import 'package:neatteam_scouting_2023/models/endgame.dart';
+import 'package:neatteam_scouting_2023/models/teleop.dart';
+
+class Match {
+  Match({required this.scouterName})
+      : fouls = 0,
+        technicalFouls = 0;
+
+  String scouterName;
+
+  int? matchNumber;
+  Alliance? alliance;
+  DriverStation? driverStation;
+
+  int fouls;
+  int technicalFouls;
+
+  Autonomous? autonomous;
+  Teleop? teleop;
+  Endgame? endgame;
+}

--- a/lib/models/team.dart
+++ b/lib/models/team.dart
@@ -1,0 +1,7 @@
+class Team {
+  Team() : matches = [];
+
+  int? teamNumber;
+  String? teamName;
+  List<Match> matches;
+}

--- a/lib/models/teleop.dart
+++ b/lib/models/teleop.dart
@@ -1,0 +1,8 @@
+// Project imports:
+import 'package:neatteam_scouting_2023/models/cycle.dart';
+
+class Teleop {
+  Teleop() : cycles = [];
+
+  List<Cycle> cycles;
+}


### PR DESCRIPTION
Closes #5.

## Enums

Added bunch of enums representing different things in the game, some are textual and some numeric. Future step is to use all the data collected and export to an CSV/XLSX file. When that happens, enum data should be used as follows:

```
Numeric enum -> obj.value
Textual enum -> obj.name
```

## Models

Added models for each step of the game. The models allow some nullable fields for rewinding to be possible (When a scouter goes back to an already completed page and makes changes). Each page should receive (Or create otherwise) a relevant model object representing the page. When the page makes changes like assigning team number, the model should be updated either instantly or at submission of a form. It is important to allow those nullable fields to support possible game flows and make sure rewinding is supported.